### PR TITLE
Correct updateGPIO() to support PCF8574

### DIFF
--- a/PCF857X.cpp
+++ b/PCF857X.cpp
@@ -295,7 +295,12 @@ void PCF857X::updateGPIO() {
 
 	/* Start communication and send GPIO values as byte */
 	Wire.beginTransmission(_address);
-	I2CWRITE(value & 0x00FF);
-	I2CWRITE((value & 0xFF00) >> 8);
+	if (_chip == CHIP_PCF8575) {
+		I2CWRITE(value & 0x00FF);
+		I2CWRITE((value & 0xFF00) >> 8);
+	}
+	else {
+		I2CWRITE(value & 0x00FF);
+	}
 	Wire.endTransmission();
 }


### PR DESCRIPTION
PCF8574 has only 8 pins and expect only 8-bit data after transmitting the I2C address. This guard already exist for reading the bus, but not for writing. My patch corrects this.